### PR TITLE
fixing bug when global id is set to a non-zero value

### DIFF
--- a/lightningjs-bootstrap.js
+++ b/lightningjs-bootstrap.js
@@ -45,6 +45,12 @@ window.lightningjs || (function(window, parentLightningjs){
             parentLoadPendingCalls = [],
             parentLoadPendingIdLookup = {},
             parentLoaded = false;
+
+        if(deferredApiCalls && deferredApiCalls[0]) {
+            var promiseFunctionId = deferredApiCalls[0][1];
+            responses[promiseFunctionId] = api;
+        }
+        
         // NOTE: root.lv contains the embed version
         api._load = function() {
             // this method gets called whenever the parent.window.onload event fires

--- a/test/test.js
+++ b/test/test.js
@@ -254,6 +254,17 @@ asyncTest("can call require() twice for the same namespace and get the exact sam
     })
 });
 
+asyncTest("can call traditional asynchronous echo function when global id is set", function(){
+    window.id = 1;
+    var testlib = loadNewTestingLibraryWithLightningjs();
+    expect(1);
+    testlib("asynchronousEcho", "hello world", function(echoText) {
+        equals(echoText, "echo:hello world");
+        start();
+        window.id = null;
+    })
+});
+
 // TODO: figure out an easy way to test the lightningjs.expensive API
 // asyncTest("expensive calls are executed only after window.onload", function(){
 // });


### PR DESCRIPTION
This is a fix for issue 3 that I opened up yesterday https://github.com/olark/lightningjs/issues/3

My fix is a very simple workaround for fixing this issue of when the page the embed code is running on has a window.id set. I'm sure there is a cleaner solution, but figured this would get the ball rolling.
